### PR TITLE
Add a working TypeScript implementation of the accounting pattern

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,3 +24,15 @@ jobs:
           java-version: "26"
           cache: maven
       - run: mvn -B --no-transfer-progress verify
+
+  typescript:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
+        with:
+          node-version: "24"
+          cache: npm
+      - run: npm ci
+      - run: npm run typecheck
+      - run: npm test

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ buildNumber.properties
 .mvn/timing.properties
 
 # Created by .ignore support plugin (hsz.mobi)
+
+### Node template
+node_modules/

--- a/README.md
+++ b/README.md
@@ -2,12 +2,23 @@
 
 Implementation of Martin Fowler's [accounting patterns article](http://martinfowler.com/apsupp/accounting.pdf) and [Accounting Narrative](http://martinfowler.com/eaaDev/AccountingNarrative.html).
 
+The same pattern is implemented twice — in Java under `src/main/java`, and in
+TypeScript under `src/main/typescript` — so the two can be read side by side.
+
 ## Building
 
-Requires JDK 26 and Maven.
+The Java implementation requires JDK 26 and Maven.
 
 ```bash
 mvn verify
+```
+
+The TypeScript implementation requires Node 24.
+
+```bash
+npm install
+npm run typecheck
+npm test
 ```
 
 ## Summary

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,1618 @@
+{
+  "name": "accounting-pattern",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "accounting-pattern",
+      "version": "1.0.0",
+      "devDependencies": {
+        "typescript": "^5.9.3",
+        "vitest": "^3.2.4"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.2.tgz",
+      "integrity": "sha512-XExcO+dvLKvVtNTibSTBej1NCAbaGhWn9Ww1ZPx80qsahhPFe/8jgWP0IchNe0F3HwkU7n8ejhH8bjonqht8mQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.2.tgz",
+      "integrity": "sha512-kXXoiPVVGQcnIYGOeaovwOURpniDBpSq4A03qkQ+BMQqtGG6HYap3xne9C1O1yo4TR3qxlCX5IqqmX6fFo2Lqg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.2.tgz",
+      "integrity": "sha512-5YfKeeI8qWfBZIX+u2xZC3Zlb3Os/gLS2sbEKM+I4ZOcsWmHS2WLysCcQZDAFRslDUU5Oiq44gf6PYN1vGwG5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.2.tgz",
+      "integrity": "sha512-O387ite7SzUyCcy3JQX4P4bLtEA7bLLkx+esve5JHnyYfNTxcVpXZo9jhdB0lTKN44gztELTdU7nS8Nr16Fs1Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.2.tgz",
+      "integrity": "sha512-n4KqkOQrraxHJcgjM1RvwbigfQKIKJVpM7xp+KsxiyUSrRdIXnt73VhrPAx0fV44hgfmIVKjxMN9J1t5jySVkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.2.tgz",
+      "integrity": "sha512-uq6suIWYP37qzGddBKPw5QEQPi6HiLGsO7UmkpfyaYNQ3D+rN6w6WfwH+nuqcGXWvawGwxOEroO4YGnFh95azw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-n+I0BTSRIoy+d6RPKnEVwql5UwBJolytvY4mAOIEJorKlqgPII8ix6slVVrfZ5Tnj7glIZvloylbB/EJPMWEXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.2.tgz",
+      "integrity": "sha512-78XJTJkvPs0kz2w61301PJjXl4g7q3JqiYMZ/M/yVI73EHBrCRTgkhu9oqG7vPqq+a/yadEW8aD+agKlk5xrmg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.2.tgz",
+      "integrity": "sha512-XlDnu2q5yoqems+xay6wSAcg9DDD7K9RLKZEBOMZm3ckNpJBvOX20tSfby8KfrrhINDyv9V2YVZKY/SpoGJI8w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.2.tgz",
+      "integrity": "sha512-pW4AC0P3it8c7do9MVM4p51FzHzdM/TZrerurgRcHJ2WTa1VQ1CIq18xncfpBJw4ojkiZZrKW2yIBWBP92j6Ug==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.2.tgz",
+      "integrity": "sha512-CYbnj78HsIeA+DhgUKgFCfvNsTHFhMMrinUrMZpDXJXKN8T3XViTZ/+wtHeVxEWY8ewSzTFN+nRmSwO2tZaLUQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.2.tgz",
+      "integrity": "sha512-buwkd8nsph4R+ajRvw0qM5Hja/TXQow3ptzWO2EbG/cqcIkHloRrdlBtQlshyYGTNFvfkfJ5tpPLVkY4DtsPfQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.2.tgz",
+      "integrity": "sha512-ZVykbDyk7519VwiNb9Lcj9m8XM6v5V9uKPvrEMkkEedVewf+0itkhahp4HDpgERXhwLRpWFypsGbG/J8s0QjJA==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.2.tgz",
+      "integrity": "sha512-CAXl+Dtd9UUuJd8pKKdwh6MLm3MUMiqMPmhZ3tTSXPqfyQ3vDl6R5hZdZ/kYojK4ofXtdfSv1tFq8XzWx3heNQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.2.tgz",
+      "integrity": "sha512-GeXCej4IQtU1B+QlDV8W/RRvbzI3O/Stss+/bCXv4lZls5WGRtu2a+3JkA3i4qIUlMXpcHebWpF8AkJhATowuA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.2.tgz",
+      "integrity": "sha512-3H1weTYZPxt/WOhByszQZybS9w5lKzUn1FDMsgEChbHWQwHYQQRfBxgCcZvPhjHfKyJjIievvMmEUawJrdY9Dg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.2.tgz",
+      "integrity": "sha512-4xTZr1FUmSoQW4XIWmit3tzQrUTZM+N3P0XV8xROKYF50XfI7xeO90+1bZvNwxIufQ9hDQVRJH5YhgPVF8A/HQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-sSATRjPeDBg3pdgHoQfoYBob11Kk1FGa9lui5RIHZCoCkJa9QKlvl3/vKz2usCmYYjs7ymJR/2Nnsqe+Hjt5nw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.2.tgz",
+      "integrity": "sha512-lqnzCV+mM0gIADaKihiCg6ifgfU2L3h5E33rNQBN1Y4MaVGnzryzmvvf7UHxprpQdE8hpqLolJ9Rl+SkIRDpyw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-AL2qJILH7lNjrDmCQDvdxMfAUIv8KMNZOvrwAQ8i8//ntL9FflhOyMJ8OZSMBb8/AWXe3/5v5S20y3zCoZWKoQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.2.tgz",
+      "integrity": "sha512-QtiuPytchRyC4rwUKhexJdQKvDuZ6hWloi3igqPQNUJCS1/v9EiO3UTOXR6A3FoMo4fnAKbWJdqaIwhOzh8qEw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.2.tgz",
+      "integrity": "sha512-WkhYDmpTjLvGlScA1rwjRUmhl4k8oXR3cIbtqWmELgU/dFeHHlEllxDvdWcNJV9rbzCexB5vz8gtNewWLgCT7Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.2.tgz",
+      "integrity": "sha512-GPMSkTOtMnv2U2F8gxe4Io6qmVs+YKyp832Etqqxr0hFngmXQ3rzwytelm3GIn7T4VviRUlf3sOgBOiTdvaf7g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.2.tgz",
+      "integrity": "sha512-PIhhEkE9uPBleRBrQEJpUn7MBnibZzbGzYWPmY3x+YoVg/95zbjB4CxPPOQ8l5tYYM4mMaCthF8/1DIfBQQyWQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.2.tgz",
+      "integrity": "sha512-YmJbfTlvU7Sdn9BB+4PRES4oB6pxgS37MAONj+hBr/cpXS1aBPKXxNnDbu+QCWPj0o9dgyxeq79g6c5P8KeuYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.2.tgz",
+      "integrity": "sha512-5ebpxr3nWMzrL/rnUI755Jkuee0bHL/Gq0WTF9lvcpv73wAp5eu8MfBUgWK9bhWvZjj7yX8etf/8tI8Ney695g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.6.0.tgz",
+      "integrity": "sha512-T7jf+5zgsZHwNJ4lvQ7/aezbyk0nNX+zJVWpmHA7VYsEx7a7qr5Rg5IbtJFqkgze5Y2sruq1RUY8Q837Od7iFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@napi-rs/lzma-linux-x64-gnu": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/lzma-linux-x64-gnu/-/lzma-linux-x64-gnu-1.5.1.tgz",
+      "integrity": "sha512-oTXEIha4SsuXdTA4Iyskj0kpdx2yVXdhd75c2v3xGrHFfVMsbhTPZU/nMPL4sWKo4pBHm3aucLaqGlF696dTyQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^22.20 || ^24.12 || >=25"
+      }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.63.1.tgz",
+      "integrity": "sha512-UZ8sUxPTiHWYX9QNdJedb1kDZSpS1t/VPWBWGSgqHNi9w3Cu6IXvu2mzbhiTiPvtrqgTQJ+zqiAq2iPIPilpaQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.63.1.tgz",
+      "integrity": "sha512-cQ4nFQABN5cDvDpbvJ7bMStCpnaVxynZrRMfUJYgxcIk9Sh54FIO1vtfkg0B69REjER77ioZ/ov+eAApx/KmLQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.63.1.tgz",
+      "integrity": "sha512-FQNqd1lRy/0QhDk3xeRIkSBiCpXCiDnZO3YLVdcDKN1UBiKToNftCzcXYNLshmPDUMlu2TdeS8tGcsU6f3YF1Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.63.1.tgz",
+      "integrity": "sha512-pvD16V939D3CloK0+qikpGaxiPrDUXTe7Y5cWOMkMSy7m1cawa8EGy/kXYi/G/cKAC4HDAbSnzCIk1WmsoOKXg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.63.1.tgz",
+      "integrity": "sha512-pcFGeL2345VwdTnJhA6zLbew+YgWB0qBG2+dMtXjCicf6+rm6kO6cOoh5VnTe0ZMrMRgRyuHmCJxZWrIdzYuOw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.63.1.tgz",
+      "integrity": "sha512-mRJlqSRulVzcKq/LKA6ICSIc3K/l4fzlVn/gePn2nXIHy8seRi5z/eeRE0d/XMBxcMldiXtQTSpRj0tkkC3g8Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.63.1.tgz",
+      "integrity": "sha512-YDUNvVM85TI3g/1OpnqKP1h4NeW/j64DfWMf+G3M809xNk1bJSnpFp4sh83NpmVE5DXnkh8ULor4LTVZKoYLHw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.63.1.tgz",
+      "integrity": "sha512-7Mcn71p9ZuQFAj+h+dhQXy/yeLePRS2yKRnmW1DijA9thKO5qap0GNOIQK4yQ6iP3SU0Mrb/yWo8h8vgRba8lw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.63.1.tgz",
+      "integrity": "sha512-4YiLQTX6U4CSl0L9cluep9A9W6UmTfqBDc2/CH6wlu54pl4E7Jn3cOD8oxzvBDEGk/JMKgJ47C8g+radF7mwvg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.63.1.tgz",
+      "integrity": "sha512-2ra8F7w8OquwZN9z2/fKFnli69wa8PLwaVzRMIPGb13ByMJwC28Fbp8YcVGoUhlYMTt7j5j9bNgpysrN2UM+vw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.63.1.tgz",
+      "integrity": "sha512-Sy20ncyhjmBP0Ml+UvQbimjlk6VFgjW5uNP+qqwHB00mTE8Bl2C1TuHTlRwK2YoXeZbee5lP2XevBWVkAQAtSQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.63.1.tgz",
+      "integrity": "sha512-noITLp8oNjYliPnGWmLyelIHwULGqbHloQHGw1rtxbWhTuWooRpnZarZQJ1y9EUC4szuCusCc+HEpUtxpIwYvA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.63.1.tgz",
+      "integrity": "sha512-hlxxXd+F1mWiAcaFR7Sv9ZQT6m6UfI8+Vy/kFJzztq2pDMU/0wZ9sish0iszNZvsQDo8Gc0i5yuFEOz5dDf6fA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.63.1.tgz",
+      "integrity": "sha512-EF7OpqQTQ/BvGqLzUi4rEHuagCV9MugAUXSHemwPW5vxZ75RR+jxO/2j95Ph2dalMpFHSVECjRoioHZgA9zOYA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.63.1.tgz",
+      "integrity": "sha512-wQO3JesW9PRkwlabQ27y7sPfVOOTLRG73I4F2UYHG5PXun3J9U3y+b7ezVKSYbsvSKGQ1k1cq8Qlun4C9kLt3w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.63.1.tgz",
+      "integrity": "sha512-ouAGwhO6wHRXdnOVCOsB0tRFkA7nhNB2Nwax6oECXN0YiN8EYUTBAOudADOB1PI+yDL61TeNx/u7MVCzksNbkQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.63.1.tgz",
+      "integrity": "sha512-q2R38Sn+1J8RxhfJ+T54wSWmyKXWec+9jgDfqO2AtArEqHO5R2aeayp5H5OYLr5UYDVGsVaZPEFUooMhYCdz5A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.63.1.tgz",
+      "integrity": "sha512-gfI5T24WLLuFfSKw7Go/zDXjAAV0fny0swTaDv+WjK7vqcw4cRhFfdsyKL1n+ukI+ooBxn3bVQnyrn06WpI50w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.63.1.tgz",
+      "integrity": "sha512-4h6XqthmB4Hspji84wvgk+ElodTsGj+dbZqHJHHtKxj4mYq0ANSEEPX9ys3moJueqsRjwpaJYH7874Itwnj2ow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.63.1.tgz",
+      "integrity": "sha512-dlfCOa87o1VAYegLQ9EKilx2JCeRofiyPGhTCmqnuXZ6bMPiycO1rq1+sKoulAp7pGLIsTIw+1x5R+zgh5LhhA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.63.1.tgz",
+      "integrity": "sha512-cjkLbOlfcm3QGhMM1J5zaZjsw1GggbN6rw9UTSSRrPrR1KkcXnN7Uq9rPw34xImQ9VOY9GN+6u2Zj80B9ptkcw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.63.1.tgz",
+      "integrity": "sha512-Li1KdUnWGE4N3e1F/B4RTB1ms+nG4WBgjByO46pkeBVX/2UBsY53xf5vK9WygVmnH3RwncIST7lkSdLSY6P9lg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.63.1.tgz",
+      "integrity": "sha512-t4ZYOSoLTgwhuFMrmTMLx/+i1DQVK7HYqMc6kY46EApwi8X0nIVphzdNoThU3xt6n+N5urG1/gxBdCaKDLavfg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.63.1.tgz",
+      "integrity": "sha512-RgroPfMmKlD1RzSDxvwgcPiy2HNQKoYV7OmwIXDsk73uKW5t6B/V8KIy27SMv/FNXFo/oSBtWc9J0X7t91ezZg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.63.1.tgz",
+      "integrity": "sha512-at8QVep6S3h5Y6gSbdGU06bRY5WJkf6WUduM9YtvYMbYhB1MOFfUgc6kehitQXzOtMSaT70q7f9ydPhpqu821w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vitest/expect": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.7.tgz",
+      "integrity": "sha512-E8eBXaKibuvH2pSZErOjdVb5vF4PbKYcrnluBTYxEk1l/VhhwZg1kZQsdtjq+CsF5CFydf2Rdkz7jDHKSisi3w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.7",
+        "@vitest/utils": "3.2.7",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.7.tgz",
+      "integrity": "sha512-Trr0hYO9CM3Wj6ksWHRhK9IZpIY6wTMO5u/MqXurMxT57sWBaOPEtP3Oq60ihZuh5JsiagKfz95OcxdEP6dBrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "3.2.7",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.7.tgz",
+      "integrity": "sha512-KUHlwqVu0sRlhCdyPdQ/wBoTfRahjUky1MubOmYw9fWfIZy1gNoHpuaaQBPAaMaVYdQYHJLurzj8ECCj5OwTqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.7.tgz",
+      "integrity": "sha512-sB9y4ovltoQP+WaUPwmSxO9WIg9Ig694Di5PalVPsYHklAdE027mehpWF2SQSVq+k6sFgaivbTjTJwZLSHbedA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "3.2.7",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.7.tgz",
+      "integrity": "sha512-7C+MwShwtBSI5Buwoyg3s/iY1eHL9PKAf+O1wVh/TdnjXUtkoL/9YQtre90i4MtNXM6edP1wJ2zOBpfCyhIS7g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.7",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.7.tgz",
+      "integrity": "sha512-Q2eQGI6d2L/hBtZ0qNuKcAGid68XK6cv1xsoaIma6PaJhHPoqcEJhYpXZ/5myCMqkNgtP6UKuBhbc0nHKnrkuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.7.tgz",
+      "integrity": "sha512-x6BDOd7dyo3PFLY3I9/HJ25X/6OurhGXk2/B9gOZNPF7XDVjeBK4k01lQE5uvDpbuheErh91qYuE1E2OEjK3Rw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.7",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.2.tgz",
+      "integrity": "sha512-HKVLS8dvII+xoKW9kmqxbRKrnWEXfJJr/FZhhJmiqIB0e053QNYFqOBouTMO/k5sID4MvCiUCvv8b9M4h32wIA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.2",
+        "@esbuild/android-arm": "0.28.2",
+        "@esbuild/android-arm64": "0.28.2",
+        "@esbuild/android-x64": "0.28.2",
+        "@esbuild/darwin-arm64": "0.28.2",
+        "@esbuild/darwin-x64": "0.28.2",
+        "@esbuild/freebsd-arm64": "0.28.2",
+        "@esbuild/freebsd-x64": "0.28.2",
+        "@esbuild/linux-arm": "0.28.2",
+        "@esbuild/linux-arm64": "0.28.2",
+        "@esbuild/linux-ia32": "0.28.2",
+        "@esbuild/linux-loong64": "0.28.2",
+        "@esbuild/linux-mips64el": "0.28.2",
+        "@esbuild/linux-ppc64": "0.28.2",
+        "@esbuild/linux-riscv64": "0.28.2",
+        "@esbuild/linux-s390x": "0.28.2",
+        "@esbuild/linux-x64": "0.28.2",
+        "@esbuild/netbsd-arm64": "0.28.2",
+        "@esbuild/netbsd-x64": "0.28.2",
+        "@esbuild/openbsd-arm64": "0.28.2",
+        "@esbuild/openbsd-x64": "0.28.2",
+        "@esbuild/openharmony-arm64": "0.28.2",
+        "@esbuild/sunos-x64": "0.28.2",
+        "@esbuild/win32-arm64": "0.28.2",
+        "@esbuild/win32-ia32": "0.28.2",
+        "@esbuild/win32-x64": "0.28.2"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.7.tgz",
+      "integrity": "sha512-qcJu88Q2IWqJsDD529JKMdwGm/dvInW4HvQnRwiH9JtihJvzGOscDtHE3x1pBKeUOTysQ8kVmLnJ2kJu7yhcGA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.28",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.28.tgz",
+      "integrity": "sha512-RRuzqDtt5Y9h3quz5hWhK+TPnsmVs6WwSU6LkJMeY4HstUEDuYTG8UJSdawMRzmzAtV+KEoG8N3Qg2qLy5vM/A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.18",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.63.1.tgz",
+      "integrity": "sha512-3Df9jsstwhccuEfmAMi9l8XUh/GOkVObmFTU7CCVBysEbcOZLl84jCtaAZMcPiMz2EGKsATzQcU+Xr3n/wU6cg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.9"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@napi-rs/lzma-linux-x64-gnu": "1.5.1",
+        "@rollup/rollup-android-arm-eabi": "4.63.1",
+        "@rollup/rollup-android-arm64": "4.63.1",
+        "@rollup/rollup-darwin-arm64": "4.63.1",
+        "@rollup/rollup-darwin-x64": "4.63.1",
+        "@rollup/rollup-freebsd-arm64": "4.63.1",
+        "@rollup/rollup-freebsd-x64": "4.63.1",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.63.1",
+        "@rollup/rollup-linux-arm-musleabihf": "4.63.1",
+        "@rollup/rollup-linux-arm64-gnu": "4.63.1",
+        "@rollup/rollup-linux-arm64-musl": "4.63.1",
+        "@rollup/rollup-linux-loong64-gnu": "4.63.1",
+        "@rollup/rollup-linux-loong64-musl": "4.63.1",
+        "@rollup/rollup-linux-ppc64-gnu": "4.63.1",
+        "@rollup/rollup-linux-ppc64-musl": "4.63.1",
+        "@rollup/rollup-linux-riscv64-gnu": "4.63.1",
+        "@rollup/rollup-linux-riscv64-musl": "4.63.1",
+        "@rollup/rollup-linux-s390x-gnu": "4.63.1",
+        "@rollup/rollup-linux-x64-gnu": "4.63.1",
+        "@rollup/rollup-linux-x64-musl": "4.63.1",
+        "@rollup/rollup-openbsd-x64": "4.63.1",
+        "@rollup/rollup-openharmony-arm64": "4.63.1",
+        "@rollup/rollup-win32-arm64-msvc": "4.63.1",
+        "@rollup/rollup-win32-ia32-msvc": "4.63.1",
+        "@rollup/rollup-win32-x64-gnu": "4.63.1",
+        "@rollup/rollup-win32-x64-msvc": "4.63.1",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/strip-literal": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.6.tgz",
+      "integrity": "sha512-u8KszXvGfU68hVcZpRHKG28T0krMuv2G5nDhiHaMLen/gIuFEgIJhaJuO69qjnXg5paSrbPMFfx3brNuN8eVSg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/vite": {
+      "version": "7.3.6",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.6.tgz",
+      "integrity": "sha512-4XP60spRGjSZFf1qYH+dJIkK2znL3zQfl9KkOV9MkkRR/3Dls0dxaBsQPTloEc5BLXWPL9vsOxopxyKoMmDueg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.6",
+        "rollup": "^4.43.0",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "lightningcss": "^1.21.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.7.tgz",
+      "integrity": "sha512-KrxIJ62Fd89gfysR4WotlgZABiz2dqFPgqGzX7s+CwsqLFomRH7777ZcrOD6+WVAh7khPQP41A+BKbpcJFrdEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.7",
+        "@vitest/mocker": "3.2.7",
+        "@vitest/pretty-format": "^3.2.7",
+        "@vitest/runner": "3.2.7",
+        "@vitest/snapshot": "3.2.7",
+        "@vitest/spy": "3.2.7",
+        "@vitest/utils": "3.2.7",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.7",
+        "@vitest/ui": "3.2.7",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "accounting-pattern",
+  "version": "1.0.0",
+  "private": true,
+  "description": "TypeScript implementation of the accounting patterns",
+  "type": "module",
+  "scripts": {
+    "test": "vitest run",
+    "typecheck": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "typescript": "^5.9.3",
+    "vitest": "^3.2.4"
+  }
+}

--- a/src/main/typescript/accounting-pattern/Customer.ts
+++ b/src/main/typescript/accounting-pattern/Customer.ts
@@ -1,0 +1,29 @@
+class Customer {
+    private name: string;
+    private serviceAgreement: ServiceAgreement;
+    private entries: Entry[] = [];
+
+    constructor(name: string, serviceAgreement: ServiceAgreement) {
+        this.name = name;
+        this.serviceAgreement = serviceAgreement;
+    }
+
+    getName(): string {
+        return this.name;
+    }
+
+    getEntry(index: number): Entry {
+        return this.entries[index];
+    }
+
+    post(eventType: EventType, eventDate: Date, quantity: Quantity): void {
+        this.entries.push(this.serviceAgreement.post(eventType, eventDate, quantity));
+    }
+
+    balance(balanceDate: Date): MonetaryAmount {
+        return this.entries
+            .filter(entry => entry.getEntryDate() < balanceDate)
+            .map(entry => entry.getAmount())
+            .reduce((acc, amount) => acc.add(amount), MonetaryAmount.ZERO);
+    }
+}

--- a/src/main/typescript/accounting-pattern/Customer.ts
+++ b/src/main/typescript/accounting-pattern/Customer.ts
@@ -1,0 +1,36 @@
+import type { Entry } from "./Entry";
+import type { EventType } from "./EventType";
+import { MonetaryAmount } from "./MonetaryAmount";
+import type { Quantity } from "./Quantity";
+import type { ServiceAgreement } from "./ServiceAgreement";
+
+/** An account holder, its service agreement, and the entries posted to it. */
+export class Customer {
+    private readonly name: string;
+    private readonly serviceAgreement: ServiceAgreement;
+    private readonly entries: Entry[] = [];
+
+    constructor(name: string, serviceAgreement: ServiceAgreement) {
+        this.name = name;
+        this.serviceAgreement = serviceAgreement;
+    }
+
+    getName(): string {
+        return this.name;
+    }
+
+    getEntry(index: number): Entry {
+        return this.entries[index];
+    }
+
+    post(eventType: EventType, eventDate: Date, quantity: Quantity): void {
+        this.entries.push(this.serviceAgreement.post(eventType, eventDate, quantity));
+    }
+
+    balance(balanceDate: Date): MonetaryAmount {
+        return this.entries
+            .filter(entry => entry.getEntryDate() < balanceDate)
+            .map(entry => entry.getAmount())
+            .reduce((total, amount) => total.add(amount), MonetaryAmount.ZERO);
+    }
+}

--- a/src/main/typescript/accounting-pattern/Entry.ts
+++ b/src/main/typescript/accounting-pattern/Entry.ts
@@ -1,0 +1,19 @@
+class Entry {
+    private entryDate: Date;
+    private entryType: EntryType;
+    private amount: MonetaryAmount;
+
+    constructor(entryDate: Date, entryType: EntryType, amount: MonetaryAmount) {
+        this.entryDate = entryDate;
+        this.entryType = entryType;
+        this.amount = amount;
+    }
+
+    getAmount(): MonetaryAmount {
+        return this.amount;
+    }
+
+    getEntryDate(): Date {
+        return this.entryDate;
+    }
+}

--- a/src/main/typescript/accounting-pattern/Entry.ts
+++ b/src/main/typescript/accounting-pattern/Entry.ts
@@ -1,0 +1,27 @@
+import type { EntryType } from "./EntryType";
+import type { MonetaryAmount } from "./MonetaryAmount";
+
+/** A single posting on a customer's account. */
+export class Entry {
+    private readonly entryDate: Date;
+    private readonly entryType: EntryType;
+    private readonly amount: MonetaryAmount;
+
+    constructor(entryDate: Date, entryType: EntryType, amount: MonetaryAmount) {
+        this.entryDate = entryDate;
+        this.entryType = entryType;
+        this.amount = amount;
+    }
+
+    getAmount(): MonetaryAmount {
+        return this.amount;
+    }
+
+    getEntryDate(): Date {
+        return this.entryDate;
+    }
+
+    getEntryType(): EntryType {
+        return this.entryType;
+    }
+}

--- a/src/main/typescript/accounting-pattern/EntryType.ts
+++ b/src/main/typescript/accounting-pattern/EntryType.ts
@@ -1,0 +1,17 @@
+class EntryType {
+    static BASE_USAGE = new EntryType("Base Usage");
+    static SERVICE = new EntryType("Service Fee");
+    private name: string;
+
+    constructor(name: string) {
+        this.name = name;
+    }
+
+    static entryType(name: string): EntryType {
+        return new EntryType(name);
+    }
+
+    getName(): string {
+        return this.name;
+    }
+}

--- a/src/main/typescript/accounting-pattern/EntryType.ts
+++ b/src/main/typescript/accounting-pattern/EntryType.ts
@@ -1,0 +1,23 @@
+/** The kind of entry a posting rule produces. */
+export class EntryType {
+    static readonly BASE_USAGE = new EntryType("Base Usage");
+    static readonly SERVICE = new EntryType("Service Fee");
+
+    private readonly name: string;
+
+    constructor(name: string) {
+        this.name = name;
+    }
+
+    static entryType(name: string): EntryType {
+        return new EntryType(name);
+    }
+
+    getName(): string {
+        return this.name;
+    }
+
+    toString(): string {
+        return `EntryType{name='${this.name}'}`;
+    }
+}

--- a/src/main/typescript/accounting-pattern/EventType.ts
+++ b/src/main/typescript/accounting-pattern/EventType.ts
@@ -1,0 +1,21 @@
+class EventType {
+    static USAGE = new EventType("usage");
+    static SERVICE = new EventType("service fee");
+    private name: string;
+
+    constructor(name: string) {
+        this.name = name;
+    }
+
+    static eventType(name: string): EventType {
+        return new EventType(name);
+    }
+
+    getName(): string {
+        return this.name;
+    }
+
+    toString(): string {
+        return `EventType{name='${this.name}'}`;
+    }
+}

--- a/src/main/typescript/accounting-pattern/EventType.ts
+++ b/src/main/typescript/accounting-pattern/EventType.ts
@@ -1,0 +1,23 @@
+/** The kind of event a customer posts against a service agreement. */
+export class EventType {
+    static readonly USAGE = new EventType("usage");
+    static readonly SERVICE = new EventType("service fee");
+
+    private readonly name: string;
+
+    constructor(name: string) {
+        this.name = name;
+    }
+
+    static eventType(name: string): EventType {
+        return new EventType(name);
+    }
+
+    getName(): string {
+        return this.name;
+    }
+
+    toString(): string {
+        return `EventType{name='${this.name}'}`;
+    }
+}

--- a/src/main/typescript/accounting-pattern/MonetaryAmount.ts
+++ b/src/main/typescript/accounting-pattern/MonetaryAmount.ts
@@ -1,0 +1,31 @@
+class MonetaryAmount {
+    static ZERO = new MonetaryAmount("USD", 0);
+    private currency: string;
+    private amount: number;
+
+    constructor(currencyName: string, amount: number) {
+        this.currency = currencyName;
+        this.amount = amount;
+    }
+
+    add(other: MonetaryAmount): MonetaryAmount {
+        if (this.currency !== other.currency) {
+            throw new Error("Currencies must be the same");
+        }
+        return new MonetaryAmount(this.currency, this.amount + other.amount);
+    }
+
+    equals(other: MonetaryAmount): boolean {
+        return this.currency === other.currency && this.amount === other.amount;
+    }
+
+    hashCode(): number {
+        let result = this.currency.hashCode();
+        result = 31 * result + this.amount;
+        return result;
+    }
+
+    getAmount(): number {
+        return this.amount;
+    }
+}

--- a/src/main/typescript/accounting-pattern/MonetaryAmount.ts
+++ b/src/main/typescript/accounting-pattern/MonetaryAmount.ts
@@ -1,0 +1,70 @@
+/**
+ * The number of decimal places a currency actually uses. USD and GBP have two,
+ * JPY has none. Unknown codes are rejected rather than silently defaulted.
+ */
+function fractionDigits(currency: string): number {
+    let digits: number | undefined;
+    try {
+        digits = new Intl.NumberFormat("en", { style: "currency", currency })
+            .resolvedOptions().maximumFractionDigits;
+    } catch {
+        throw new Error(`Unknown currency: ${currency}`);
+    }
+    if (digits === undefined) {
+        throw new Error(`Currency has no known scale: ${currency}`);
+    }
+    return digits;
+}
+
+/** Java's String.hashCode, so the two implementations agree on a value. */
+function hashString(value: string): number {
+    let hash = 0;
+    for (let i = 0; i < value.length; i++) {
+        hash = (Math.imul(31, hash) + value.charCodeAt(i)) | 0;
+    }
+    return hash;
+}
+
+/**
+ * An immutable amount of money in a single currency.
+ *
+ * The amount is rounded on construction to the decimal places its currency
+ * uses, so amounts that represent the same sum of money compare equal and
+ * repeated `add` calls cannot accumulate binary floating-point drift.
+ */
+export class MonetaryAmount {
+    static readonly ZERO = new MonetaryAmount("USD", 0);
+
+    private readonly currency: string;
+    private readonly amount: number;
+
+    constructor(currencyName: string, amount: number) {
+        const scale = 10 ** fractionDigits(currencyName);
+        this.currency = currencyName;
+        this.amount = Math.round(amount * scale) / scale;
+    }
+
+    add(other: MonetaryAmount): MonetaryAmount {
+        if (this.currency !== other.currency) {
+            throw new Error(
+                `Cannot add amounts with different currencies: ${this.currency} != ${other.currency}`);
+        }
+        return new MonetaryAmount(this.currency, this.amount + other.amount);
+    }
+
+    equals(other: MonetaryAmount): boolean {
+        return this.currency === other.currency && this.amount === other.amount;
+    }
+
+    hashCode(): number {
+        return (Math.imul(31, hashString(this.currency)) + this.amount) | 0;
+    }
+
+    getCurrency(): string {
+        return this.currency;
+    }
+
+    getAmount(): number {
+        return this.amount;
+    }
+}

--- a/src/main/typescript/accounting-pattern/MultiplyByRatePostingRule.ts
+++ b/src/main/typescript/accounting-pattern/MultiplyByRatePostingRule.ts
@@ -1,0 +1,9 @@
+class MultiplyByRatePostingRule extends PostingRule {
+    constructor(type: EntryType) {
+        super(type);
+    }
+
+    protected calculateAmount(quantity: Quantity, rate: number): MonetaryAmount {
+        return new MonetaryAmount("USD", quantity.getValue() * rate);
+    }
+}

--- a/src/main/typescript/accounting-pattern/MultiplyByRatePostingRule.ts
+++ b/src/main/typescript/accounting-pattern/MultiplyByRatePostingRule.ts
@@ -1,0 +1,15 @@
+import type { EntryType } from "./EntryType";
+import { MonetaryAmount } from "./MonetaryAmount";
+import { PostingRule } from "./PostingRule";
+import type { Quantity } from "./Quantity";
+
+/** Charges the agreement's rate for every unit of quantity. */
+export class MultiplyByRatePostingRule extends PostingRule {
+    constructor(type: EntryType) {
+        super(type);
+    }
+
+    protected calculateAmount(quantity: Quantity, rate: number): MonetaryAmount {
+        return new MonetaryAmount("USD", quantity.getValue() * rate);
+    }
+}

--- a/src/main/typescript/accounting-pattern/PostingRule.ts
+++ b/src/main/typescript/accounting-pattern/PostingRule.ts
@@ -1,0 +1,13 @@
+abstract class PostingRule {
+    protected eventType: EntryType;
+
+    protected constructor(type: EntryType) {
+        this.eventType = type;
+    }
+
+    protected abstract calculateAmount(quantity: Quantity, rate: number): MonetaryAmount;
+
+    public processEvent(eventDate: Date, quantity: Quantity, rate: number): Entry {
+        return new Entry(eventDate, this.eventType, this.calculateAmount(quantity, rate));
+    }
+}

--- a/src/main/typescript/accounting-pattern/PostingRule.ts
+++ b/src/main/typescript/accounting-pattern/PostingRule.ts
@@ -1,0 +1,19 @@
+import { Entry } from "./Entry";
+import type { EntryType } from "./EntryType";
+import type { MonetaryAmount } from "./MonetaryAmount";
+import type { Quantity } from "./Quantity";
+
+/** Turns an event into the entry it should post. */
+export abstract class PostingRule {
+    protected readonly entryType: EntryType;
+
+    protected constructor(type: EntryType) {
+        this.entryType = type;
+    }
+
+    protected abstract calculateAmount(quantity: Quantity, rate: number): MonetaryAmount;
+
+    processEvent(eventDate: Date, quantity: Quantity, rate: number): Entry {
+        return new Entry(eventDate, this.entryType, this.calculateAmount(quantity, rate));
+    }
+}

--- a/src/main/typescript/accounting-pattern/Quantity.ts
+++ b/src/main/typescript/accounting-pattern/Quantity.ts
@@ -1,0 +1,11 @@
+class Quantity {
+    private amount: number;
+
+    constructor(amount: number) {
+        this.amount = amount;
+    }
+
+    getValue(): number {
+        return this.amount;
+    }
+}

--- a/src/main/typescript/accounting-pattern/Quantity.ts
+++ b/src/main/typescript/accounting-pattern/Quantity.ts
@@ -1,0 +1,14 @@
+export class Quantity {
+    private readonly amount: number;
+
+    constructor(amount: number) {
+        if (amount < 0) {
+            throw new Error(`Quantity cannot be negative: ${amount}`);
+        }
+        this.amount = amount;
+    }
+
+    getValue(): number {
+        return this.amount;
+    }
+}

--- a/src/main/typescript/accounting-pattern/ServiceAgreement.ts
+++ b/src/main/typescript/accounting-pattern/ServiceAgreement.ts
@@ -1,0 +1,38 @@
+class ServiceAgreement {
+    private rate: number;
+    private postingRules: Map<EventType, TemporalCollection<PostingRule>>;
+
+    constructor(rate: number) {
+        this.rate = rate;
+        this.postingRules = new Map<EventType, TemporalCollection<PostingRule>>();
+    }
+
+    addPostingRule(eventType: EventType, rule: PostingRule, effectiveDate: Date): ServiceAgreement {
+        this.temporalCollection(eventType).put(effectiveDate, rule);
+        return this;
+    }
+
+    getPostingRule(eventType: EventType, when: Date): PostingRule | null {
+        return this.temporalCollection(eventType).get(when);
+    }
+
+    private temporalCollection(eventType: EventType): TemporalCollection<PostingRule> {
+        if (!this.postingRules.has(eventType)) {
+            this.postingRules.set(eventType, new TemporalCollection<PostingRule>());
+        }
+        return this.postingRules.get(eventType)!;
+    }
+
+    getRate(): number {
+        return this.rate;
+    }
+
+    post(eventType: EventType, eventDate: Date, quantity: Quantity): Entry {
+        const postingRule = this.getPostingRule(eventType, eventDate);
+
+        if (!postingRule) {
+            throw new Error(`No posting rule for ${eventType} on ${eventDate}`);
+        }
+        return postingRule.processEvent(eventDate, quantity, this.rate);
+    }
+}

--- a/src/main/typescript/accounting-pattern/ServiceAgreement.ts
+++ b/src/main/typescript/accounting-pattern/ServiceAgreement.ts
@@ -1,0 +1,48 @@
+import type { Entry } from "./Entry";
+import type { EventType } from "./EventType";
+import type { PostingRule } from "./PostingRule";
+import type { Quantity } from "./Quantity";
+import { TemporalCollection } from "./TemporalCollection";
+
+/** The posting rules in force for a customer, and when each took effect. */
+export class ServiceAgreement {
+    private readonly rate: number;
+    // Keyed by event type name: a Map compares object keys by identity, so
+    // EventType.eventType("usage") would not find EventType.USAGE's rules.
+    private readonly postingRules = new Map<string, TemporalCollection<PostingRule>>();
+
+    constructor(rate: number) {
+        this.rate = rate;
+    }
+
+    addPostingRule(eventType: EventType, rule: PostingRule, effectiveDate: Date): ServiceAgreement {
+        this.temporalCollection(eventType).put(effectiveDate, rule);
+        return this;
+    }
+
+    getPostingRule(eventType: EventType, when: Date): PostingRule | null {
+        return this.temporalCollection(eventType).get(when);
+    }
+
+    private temporalCollection(eventType: EventType): TemporalCollection<PostingRule> {
+        const key = eventType.getName();
+        let rules = this.postingRules.get(key);
+        if (!rules) {
+            rules = new TemporalCollection<PostingRule>();
+            this.postingRules.set(key, rules);
+        }
+        return rules;
+    }
+
+    getRate(): number {
+        return this.rate;
+    }
+
+    post(eventType: EventType, eventDate: Date, quantity: Quantity): Entry {
+        const postingRule = this.getPostingRule(eventType, eventDate);
+        if (!postingRule) {
+            throw new Error(`No posting rule for ${eventType} on ${eventDate.toISOString()}`);
+        }
+        return postingRule.processEvent(eventDate, quantity, this.rate);
+    }
+}

--- a/src/main/typescript/accounting-pattern/TemporalCollection.ts
+++ b/src/main/typescript/accounting-pattern/TemporalCollection.ts
@@ -1,0 +1,17 @@
+class TemporalCollection<T> {
+    private entries: Map<Date, T> = new Map<Date, T>();
+
+    put(date: Date, rule: T): void {
+        this.entries.set(date, rule);
+    }
+
+    get(when: Date): T | null {
+        const sortedDates = Array.from(this.entries.keys()).sort((a, b) => b.getTime() - a.getTime());
+        for (const date of sortedDates) {
+            if (when >= date) {
+                return this.entries.get(date) || null;
+            }
+        }
+        return null;
+    }
+}

--- a/src/main/typescript/accounting-pattern/TemporalCollection.ts
+++ b/src/main/typescript/accounting-pattern/TemporalCollection.ts
@@ -1,0 +1,27 @@
+/**
+ * A collection of values indexed by the date they took effect. `get` answers
+ * with the value that was in effect on a given date.
+ */
+export class TemporalCollection<T> {
+    // Keyed by time value rather than by Date, which a Map compares by identity:
+    // two Dates for the same instant are different keys.
+    private readonly entries = new Map<number, T>();
+
+    put(date: Date, value: T): void {
+        this.entries.set(date.getTime(), value);
+    }
+
+    get(when: Date): T | null {
+        const asAt = when.getTime();
+        let effectiveFrom = Number.NEGATIVE_INFINITY;
+        let effective: T | null = null;
+
+        for (const [date, value] of this.entries) {
+            if (date <= asAt && date > effectiveFrom) {
+                effectiveFrom = date;
+                effective = value;
+            }
+        }
+        return effective;
+    }
+}

--- a/src/test/typescript/accounting-pattern/AcceptanceTest.ts
+++ b/src/test/typescript/accounting-pattern/AcceptanceTest.ts
@@ -1,0 +1,31 @@
+import { Customer } from "../../main/typescript/accounting-pattern/Customer";
+import { ServiceAgreement } from "../../main/typescript/accounting-pattern/ServiceAgreement";
+import { EventType } from "../../main/typescript/accounting-pattern/EventType";
+import { MultiplyByRatePostingRule } from "../../main/typescript/accounting-pattern/MultiplyByRatePostingRule";
+import { AnnualServiceFeeRule } from "./AnnualServiceFeeRule";
+import { EntryType } from "../../main/typescript/accounting-pattern/EntryType";
+import { Quantity } from "../../main/typescript/accounting-pattern/Quantity";
+
+describe("Acceptance Test", () => {
+    it("should pass the acceptance test", () => {
+        const effectiveDate = new Date(1999, 9, 1);
+        const customer = new Customer("Acme Coffee Makers",
+            new ServiceAgreement(10)
+                .addPostingRule(EventType.USAGE, new MultiplyByRatePostingRule(EntryType.BASE_USAGE), effectiveDate)
+                .addPostingRule(EventType.SERVICE, new AnnualServiceFeeRule(EntryType.SERVICE, 100), effectiveDate)
+                .addPostingRule(EventType.SERVICE, new AnnualServiceFeeRule(EntryType.SERVICE, 1000), new Date(2001, 9, 1))
+        );
+
+        customer.post(EventType.USAGE, new Date(1999, 11, 1), new Quantity(50));
+        customer.post(EventType.SERVICE, new Date(2000, 9, 1), new Quantity(1));
+
+        expect(customer.balance(new Date(2020, 9, 1)).getAmount()).toBe(600);
+
+        customer.post(EventType.USAGE, new Date(1999, 11, 1), new Quantity(50));
+
+        expect(customer.balance(new Date(2020, 9, 1)).getAmount()).toBe(1100);
+
+        customer.post(EventType.SERVICE, new Date(2001, 10, 1), new Quantity(1));
+        expect(customer.balance(new Date(2020, 9, 1)).getAmount()).toBe(2100);
+    });
+});

--- a/src/test/typescript/accounting-pattern/AcceptanceTest.ts
+++ b/src/test/typescript/accounting-pattern/AcceptanceTest.ts
@@ -1,0 +1,31 @@
+import { Customer } from "../../../main/typescript/accounting-pattern/Customer";
+import { ServiceAgreement } from "../../../main/typescript/accounting-pattern/ServiceAgreement";
+import { EventType } from "../../../main/typescript/accounting-pattern/EventType";
+import { MultiplyByRatePostingRule } from "../../../main/typescript/accounting-pattern/MultiplyByRatePostingRule";
+import { AnnualServiceFeeRule } from "./AnnualServiceFeeRule";
+import { EntryType } from "../../../main/typescript/accounting-pattern/EntryType";
+import { Quantity } from "../../../main/typescript/accounting-pattern/Quantity";
+
+describe("Acceptance Test", () => {
+    it("should pass the acceptance test", () => {
+        const effectiveDate = new Date(1999, 9, 1);
+        const customer = new Customer("Acme Coffee Makers",
+            new ServiceAgreement(10)
+                .addPostingRule(EventType.USAGE, new MultiplyByRatePostingRule(EntryType.BASE_USAGE), effectiveDate)
+                .addPostingRule(EventType.SERVICE, new AnnualServiceFeeRule(EntryType.SERVICE, 100), effectiveDate)
+                .addPostingRule(EventType.SERVICE, new AnnualServiceFeeRule(EntryType.SERVICE, 1000), new Date(2001, 9, 1))
+        );
+
+        customer.post(EventType.USAGE, new Date(1999, 11, 1), new Quantity(50));
+        customer.post(EventType.SERVICE, new Date(2000, 9, 1), new Quantity(1));
+
+        expect(customer.balance(new Date(2020, 9, 1)).getAmount()).toBe(600);
+
+        customer.post(EventType.USAGE, new Date(1999, 11, 1), new Quantity(50));
+
+        expect(customer.balance(new Date(2020, 9, 1)).getAmount()).toBe(1100);
+
+        customer.post(EventType.SERVICE, new Date(2001, 10, 1), new Quantity(1));
+        expect(customer.balance(new Date(2020, 9, 1)).getAmount()).toBe(2100);
+    });
+});

--- a/src/test/typescript/accounting-pattern/AnnualServiceFeeRule.ts
+++ b/src/test/typescript/accounting-pattern/AnnualServiceFeeRule.ts
@@ -1,0 +1,17 @@
+import { PostingRule } from "../../../main/typescript/accounting-pattern/PostingRule";
+import { EntryType } from "../../../main/typescript/accounting-pattern/EntryType";
+import { Quantity } from "../../../main/typescript/accounting-pattern/Quantity";
+import { MonetaryAmount } from "../../../main/typescript/accounting-pattern/MonetaryAmount";
+
+class AnnualServiceFeeRule extends PostingRule {
+    private amount: number;
+
+    constructor(service: EntryType, amount: number) {
+        super(service);
+        this.amount = amount;
+    }
+
+    protected calculateAmount(quantity: Quantity, rate: number): MonetaryAmount {
+        return new MonetaryAmount("USD", quantity.getValue() * this.amount);
+    }
+}

--- a/src/test/typescript/accounting-pattern/AnnualServiceFeeRule.ts
+++ b/src/test/typescript/accounting-pattern/AnnualServiceFeeRule.ts
@@ -1,0 +1,17 @@
+import { PostingRule } from "../../../main/typescript/accounting-pattern/PostingRule";
+import { EntryType } from "../../../main/typescript/accounting-pattern/EntryType";
+import { Quantity } from "../../../main/typescript/accounting-pattern/Quantity";
+import { MonetaryAmount } from "../../../main/typescript/accounting-pattern/MonetaryAmount";
+
+export class AnnualServiceFeeRule extends PostingRule {
+    private amount: number;
+
+    constructor(service: EntryType, amount: number) {
+        super(service);
+        this.amount = amount;
+    }
+
+    protected calculateAmount(quantity: Quantity, rate: number): MonetaryAmount {
+        return new MonetaryAmount("USD", quantity.getValue() * this.amount);
+    }
+}

--- a/src/test/typescript/accounting-pattern/CustomerTest.ts
+++ b/src/test/typescript/accounting-pattern/CustomerTest.ts
@@ -1,0 +1,34 @@
+import { Customer } from "../../main/typescript/accounting-pattern/Customer";
+import { ServiceAgreement } from "../../main/typescript/accounting-pattern/ServiceAgreement";
+import { EventType } from "../../main/typescript/accounting-pattern/EventType";
+import { EntryType } from "../../main/typescript/accounting-pattern/EntryType";
+import { MultiplyByRatePostingRule } from "../../main/typescript/accounting-pattern/MultiplyByRatePostingRule";
+import { Quantity } from "../../main/typescript/accounting-pattern/Quantity";
+import { MonetaryAmount } from "../../main/typescript/accounting-pattern/MonetaryAmount";
+import { Entry } from "../../main/typescript/accounting-pattern/Entry";
+
+describe("Customer", () => {
+    it("should create a valid entry when posting an event", () => {
+        const effectiveDate = new Date(1999, 9, 1);
+        const customer = new Customer("Acme Coffee Makers",
+            new ServiceAgreement(10)
+                .addPostingRule(EventType.USAGE, new MultiplyByRatePostingRule(EntryType.BASE_USAGE), effectiveDate)
+        );
+
+        customer.post(EventType.USAGE, effectiveDate, new Quantity(50));
+
+        const resultingEntry = customer.getEntry(0);
+        expect(resultingEntry.getAmount()).toEqual(new MonetaryAmount("USD", 500));
+    });
+
+    it("should throw an error when posting an event without a posting rule", () => {
+        const effectiveDate = new Date(1999, 9, 1);
+        const customer = new Customer("Acme Coffee Makers", new ServiceAgreement(10));
+
+        expect(() => customer.post(EventType.USAGE, effectiveDate, new Quantity(50))).toThrow();
+    });
+
+    it("should have a name", () => {
+        expect(new Customer("foo", new ServiceAgreement(1)).getName()).toEqual("foo");
+    });
+});

--- a/src/test/typescript/accounting-pattern/CustomerTest.ts
+++ b/src/test/typescript/accounting-pattern/CustomerTest.ts
@@ -1,0 +1,34 @@
+import { Customer } from "../../../main/typescript/accounting-pattern/Customer";
+import { ServiceAgreement } from "../../../main/typescript/accounting-pattern/ServiceAgreement";
+import { EventType } from "../../../main/typescript/accounting-pattern/EventType";
+import { EntryType } from "../../../main/typescript/accounting-pattern/EntryType";
+import { MultiplyByRatePostingRule } from "../../../main/typescript/accounting-pattern/MultiplyByRatePostingRule";
+import { Quantity } from "../../../main/typescript/accounting-pattern/Quantity";
+import { MonetaryAmount } from "../../../main/typescript/accounting-pattern/MonetaryAmount";
+import { Entry } from "../../../main/typescript/accounting-pattern/Entry";
+
+describe("Customer", () => {
+    it("should create a valid entry when posting an event", () => {
+        const effectiveDate = new Date(1999, 9, 1);
+        const customer = new Customer("Acme Coffee Makers",
+            new ServiceAgreement(10)
+                .addPostingRule(EventType.USAGE, new MultiplyByRatePostingRule(EntryType.BASE_USAGE), effectiveDate)
+        );
+
+        customer.post(EventType.USAGE, effectiveDate, new Quantity(50));
+
+        const resultingEntry: Entry = customer.getEntry(0);
+        expect(resultingEntry.getAmount()).toEqual(new MonetaryAmount("USD", 500));
+    });
+
+    it("should throw an error when posting an event without a posting rule", () => {
+        const effectiveDate = new Date(1999, 9, 1);
+        const customer = new Customer("Acme Coffee Makers", new ServiceAgreement(10));
+
+        expect(() => customer.post(EventType.USAGE, effectiveDate, new Quantity(50))).toThrow();
+    });
+
+    it("should have a name", () => {
+        expect(new Customer("foo", new ServiceAgreement(1)).getName()).toEqual("foo");
+    });
+});

--- a/src/test/typescript/accounting-pattern/EntryTest.ts
+++ b/src/test/typescript/accounting-pattern/EntryTest.ts
@@ -1,0 +1,14 @@
+import { Entry } from "../../main/typescript/accounting-pattern/Entry";
+import { EntryType } from "../../main/typescript/accounting-pattern/EntryType";
+import { MonetaryAmount } from "../../main/typescript/accounting-pattern/MonetaryAmount";
+
+describe("Entry", () => {
+    it("should have a date and amount", () => {
+        const entryDate = new Date();
+        const entryType = EntryType.entryType("foo");
+        const amount = new MonetaryAmount("USD", 1);
+        const entry = new Entry(entryDate, entryType, amount);
+
+        expect(entry.getAmount()).toEqual(amount);
+    });
+});

--- a/src/test/typescript/accounting-pattern/EntryTest.ts
+++ b/src/test/typescript/accounting-pattern/EntryTest.ts
@@ -1,0 +1,14 @@
+import { Entry } from "../../../main/typescript/accounting-pattern/Entry";
+import { EntryType } from "../../../main/typescript/accounting-pattern/EntryType";
+import { MonetaryAmount } from "../../../main/typescript/accounting-pattern/MonetaryAmount";
+
+describe("Entry", () => {
+    it("should have a date and amount", () => {
+        const entryDate = new Date();
+        const entryType = EntryType.entryType("foo");
+        const amount = new MonetaryAmount("USD", 1);
+        const entry = new Entry(entryDate, entryType, amount);
+
+        expect(entry.getAmount()).toEqual(amount);
+    });
+});

--- a/src/test/typescript/accounting-pattern/MonetaryAmountTest.ts
+++ b/src/test/typescript/accounting-pattern/MonetaryAmountTest.ts
@@ -1,0 +1,35 @@
+import { MonetaryAmount } from "../../main/typescript/accounting-pattern/MonetaryAmount";
+
+describe("MonetaryAmount", () => {
+    it("should be different if amounts differ", () => {
+        const monetaryAmount1 = new MonetaryAmount("USD", 1);
+        const monetaryAmount2 = new MonetaryAmount("USD", 2);
+
+        expect(monetaryAmount1.equals(monetaryAmount2)).toBe(false);
+    });
+
+    it("should be different if currencies differ", () => {
+        const monetaryAmount1 = new MonetaryAmount("USD", 1);
+        const monetaryAmount2 = new MonetaryAmount("GBP", 1);
+
+        expect(monetaryAmount1.equals(monetaryAmount2)).toBe(false);
+    });
+
+    it("should be the same if currency and value match", () => {
+        const monetaryAmount1 = new MonetaryAmount("USD", 1);
+        const monetaryAmount2 = new MonetaryAmount("USD", 1);
+
+        expect(monetaryAmount1.equals(monetaryAmount2)).toBe(true);
+    });
+
+    it("should have a hashcode that varies by currency and value", () => {
+        const monetaryAmount1 = new MonetaryAmount("USD", 1);
+        const monetaryAmount2 = new MonetaryAmount("USD", 1);
+        const monetaryAmount3 = new MonetaryAmount("GBP", 1);
+        const monetaryAmount4 = new MonetaryAmount("USD", 2);
+
+        expect(monetaryAmount1.hashCode()).toBe(monetaryAmount2.hashCode());
+        expect(monetaryAmount1.hashCode()).not.toBe(monetaryAmount3.hashCode());
+        expect(monetaryAmount1.hashCode()).not.toBe(monetaryAmount4.hashCode());
+    });
+});

--- a/src/test/typescript/accounting-pattern/MonetaryAmountTest.ts
+++ b/src/test/typescript/accounting-pattern/MonetaryAmountTest.ts
@@ -1,0 +1,35 @@
+import { MonetaryAmount } from "../../../main/typescript/accounting-pattern/MonetaryAmount";
+
+describe("MonetaryAmount", () => {
+    it("should be different if amounts differ", () => {
+        const monetaryAmount1 = new MonetaryAmount("USD", 1);
+        const monetaryAmount2 = new MonetaryAmount("USD", 2);
+
+        expect(monetaryAmount1.equals(monetaryAmount2)).toBe(false);
+    });
+
+    it("should be different if currencies differ", () => {
+        const monetaryAmount1 = new MonetaryAmount("USD", 1);
+        const monetaryAmount2 = new MonetaryAmount("GBP", 1);
+
+        expect(monetaryAmount1.equals(monetaryAmount2)).toBe(false);
+    });
+
+    it("should be the same if currency and value match", () => {
+        const monetaryAmount1 = new MonetaryAmount("USD", 1);
+        const monetaryAmount2 = new MonetaryAmount("USD", 1);
+
+        expect(monetaryAmount1.equals(monetaryAmount2)).toBe(true);
+    });
+
+    it("should have a hashcode that varies by currency and value", () => {
+        const monetaryAmount1 = new MonetaryAmount("USD", 1);
+        const monetaryAmount2 = new MonetaryAmount("USD", 1);
+        const monetaryAmount3 = new MonetaryAmount("GBP", 1);
+        const monetaryAmount4 = new MonetaryAmount("USD", 2);
+
+        expect(monetaryAmount1.hashCode()).toBe(monetaryAmount2.hashCode());
+        expect(monetaryAmount1.hashCode()).not.toBe(monetaryAmount3.hashCode());
+        expect(monetaryAmount1.hashCode()).not.toBe(monetaryAmount4.hashCode());
+    });
+});

--- a/src/test/typescript/accounting-pattern/TemporalCollectionTest.ts
+++ b/src/test/typescript/accounting-pattern/TemporalCollectionTest.ts
@@ -1,0 +1,34 @@
+import { TemporalCollection } from "../../main/typescript/accounting-pattern/TemporalCollection";
+
+describe("TemporalCollection", () => {
+    it("should return null when empty", () => {
+        const collection = new TemporalCollection<string>();
+        expect(collection.get(new Date())).toBeNull();
+    });
+
+    it("should return null if none valid", () => {
+        const collection = new TemporalCollection<string>();
+        collection.put(new Date(Date.now() + 86400000), "foo"); // 1 day in the future
+        expect(collection.get(new Date())).toBeNull();
+    });
+
+    it("should return value if in range", () => {
+        const collection = new TemporalCollection<string>();
+        collection.put(new Date(Date.now() - 86400000), "foo"); // 1 day in the past
+        expect(collection.get(new Date())).toBe("foo");
+    });
+
+    it("should return most recent", () => {
+        const collection = new TemporalCollection<string>();
+        collection.put(new Date(Date.now() - 172800000), "Day before Yesterday"); // 2 days in the past
+        collection.put(new Date(Date.now() - 86400000), "Yesterday"); // 1 day in the past
+        expect(collection.get(new Date())).toBe("Yesterday");
+    });
+
+    it("should return for same day", () => {
+        const collection = new TemporalCollection<string>();
+        const yesterday = new Date(Date.now() - 86400000); // 1 day in the past
+        collection.put(yesterday, "Yesterday");
+        expect(collection.get(yesterday)).toBe("Yesterday");
+    });
+});

--- a/src/test/typescript/accounting-pattern/TemporalCollectionTest.ts
+++ b/src/test/typescript/accounting-pattern/TemporalCollectionTest.ts
@@ -1,0 +1,34 @@
+import { TemporalCollection } from "../../../main/typescript/accounting-pattern/TemporalCollection";
+
+describe("TemporalCollection", () => {
+    it("should return null when empty", () => {
+        const collection = new TemporalCollection<string>();
+        expect(collection.get(new Date())).toBeNull();
+    });
+
+    it("should return null if none valid", () => {
+        const collection = new TemporalCollection<string>();
+        collection.put(new Date(Date.now() + 86400000), "foo"); // 1 day in the future
+        expect(collection.get(new Date())).toBeNull();
+    });
+
+    it("should return value if in range", () => {
+        const collection = new TemporalCollection<string>();
+        collection.put(new Date(Date.now() - 86400000), "foo"); // 1 day in the past
+        expect(collection.get(new Date())).toBe("foo");
+    });
+
+    it("should return most recent", () => {
+        const collection = new TemporalCollection<string>();
+        collection.put(new Date(Date.now() - 172800000), "Day before Yesterday"); // 2 days in the past
+        collection.put(new Date(Date.now() - 86400000), "Yesterday"); // 1 day in the past
+        expect(collection.get(new Date())).toBe("Yesterday");
+    });
+
+    it("should return for same day", () => {
+        const collection = new TemporalCollection<string>();
+        const yesterday = new Date(Date.now() - 86400000); // 1 day in the past
+        collection.put(yesterday, "Yesterday");
+        expect(collection.get(yesterday)).toBe("Yesterday");
+    });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": false,
+    "noFallthroughCasesInSwitch": true,
+    "forceConsistentCasingInFileNames": true,
+    "verbatimModuleSyntax": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "types": ["vitest/globals"]
+  },
+  "include": ["src/main/typescript/**/*.ts", "src/test/typescript/**/*.ts"]
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    globals: true,
+    // The Java side names its tests *Test.java; the TypeScript side matches,
+    // so the default *.test.ts / *.spec.ts patterns would find nothing.
+    include: ["src/test/typescript/**/*Test.ts"],
+  },
+});


### PR DESCRIPTION
Closes #5.

Rebuilt on current `master`. The original branch predated the Java
modernisation, so merging it as it stood would have reverted that work.

## The TypeScript could never have run

- No file exported anything, and no source file imported its dependencies.
- Test imports were one directory level short (`../../main/...` from
  `src/test/typescript/accounting-pattern/`), so every module resolved to nothing.
- There was no `package.json`, `tsconfig.json`, or test runner, so the
  jest-style specs had never been executed.

## Toolchain

`package.json`, a strict `tsconfig.json`, and vitest — with `include` pointed at
`*Test.ts` so the TypeScript tests keep the same naming as the Java ones.

## Defects fixed

- **`MonetaryAmount.hashCode`** called `String.prototype.hashCode`, which does
  not exist and threw. It now hashes the currency the way Java's `String` does,
  so both implementations agree on a value.
- **`MonetaryAmount`** rounds to its currency's scale on construction, mirroring
  the Java fix in #17, so repeated `add` cannot accumulate binary float drift.
- **`TemporalCollection`** keyed its map by `Date`. `Map` compares object keys by
  identity, so two `Date`s for the same instant were separate entries. It keys on
  the time value now.
- **`ServiceAgreement`** keyed posting rules by `EventType` identity, so a type
  built with `EventType.eventType("usage")` never found the rules registered
  against the `EventType.USAGE` singleton. It keys on the name.

## CI

The gate gains a `typescript` job running `npm run typecheck` and `npm test`
alongside the existing Maven job.

## Verification

Java: 22 tests, 0 failures. TypeScript: 14 tests, 0 failures. Both green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N9VxaAaU3kue6jM65tyhXy