### PR TITLE
Upgrade to Java 26, fix the red build, and normalise monetary scale

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,14 @@
 
 Implementation of Martin Fowler's [accounting patterns article](http://martinfowler.com/apsupp/accounting.pdf) and [Accounting Narrative](http://martinfowler.com/eaaDev/AccountingNarrative.html).
 
+## Building
+
+Requires JDK 26 and Maven.
+
+```bash
+mvn verify
+```
+
 ## Summary
 
 The accounting pattern is a design pattern used to manage financial transactions and ensure accurate financial reporting. It involves the following key concepts:

--- a/pom.xml
+++ b/pom.xml
@@ -8,8 +8,7 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <maven.compiler.source>21</maven.compiler.source>
-        <maven.compiler.target>21</maven.compiler.target>
+        <maven.compiler.release>26</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <junit.version>5.14.4</junit.version>
     </properties>
@@ -26,18 +25,13 @@
 
     <build>
         <plugins>
-            <!-- Compiler plugin to use Java 21 -->
+            <!-- Compiler plugin targeting the Java release set above -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.16.0</version>
                 <configuration>
-                    <source>${maven.compiler.source}</source>
-                    <target>${maven.compiler.target}</target>
                     <parameters>true</parameters>
-                    <compilerArgs>
-                        <arg>-parameters</arg>
-                    </compilerArgs>
                 </configuration>
             </plugin>
             <!-- Surefire plugin for running tests -->

--- a/src/main/java/accounting/patterns/Entry.java
+++ b/src/main/java/accounting/patterns/Entry.java
@@ -7,7 +7,7 @@ import java.util.Objects;
  * Represents an immutable accounting entry with a date, type, and monetary amount.
  * This class is thread-safe and can be used as a value type.
  */
-public final record Entry(
+public record Entry(
     LocalDate entryDate,
     EntryType entryType,
     MonetaryAmount amount

--- a/src/main/java/accounting/patterns/EntryType.java
+++ b/src/main/java/accounting/patterns/EntryType.java
@@ -1,5 +1,7 @@
 package accounting.patterns;
 
+import java.util.Arrays;
+
 /**
  * Represents the type of an accounting entry.
  * This enum defines the standard entry types used in the accounting system.
@@ -43,11 +45,10 @@ public enum EntryType {
      * @throws IllegalArgumentException if no EntryType matches the given name
      */
     public static EntryType fromName(String name) {
-        for (EntryType type : values()) {
-            if (type.getName().equalsIgnoreCase(name)) {
-                return type;
-            }
-        }
-        throw new IllegalArgumentException("No EntryType found for name: " + name);
+        return Arrays.stream(values())
+                .filter(type -> type.getName().equalsIgnoreCase(name))
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException(
+                        "No EntryType found for name: " + name));
     }
 }

--- a/src/main/java/accounting/patterns/EventType.java
+++ b/src/main/java/accounting/patterns/EventType.java
@@ -1,5 +1,7 @@
 package accounting.patterns;
 
+import java.util.Arrays;
+
 /**
  * Represents the type of an accounting event.
  * This enum defines the standard event types used in the accounting system.
@@ -43,11 +45,10 @@ public enum EventType {
      * @throws IllegalArgumentException if no EventType matches the given name
      */
     public static EventType fromName(String name) {
-        for (EventType type : values()) {
-            if (type.getName().equalsIgnoreCase(name)) {
-                return type;
-            }
-        }
-        throw new IllegalArgumentException("No EventType found for name: " + name);
+        return Arrays.stream(values())
+                .filter(type -> type.getName().equalsIgnoreCase(name))
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException(
+                        "No EventType found for name: " + name));
     }
 }

--- a/src/main/java/accounting/patterns/MonetaryAmount.java
+++ b/src/main/java/accounting/patterns/MonetaryAmount.java
@@ -11,11 +11,16 @@ import java.util.Objects;
  *
  * <p>The amount is normalised on construction to the number of decimal places
  * the currency actually uses ({@link Currency#getDefaultFractionDigits()}), so
- * two amounts that represent the same sum of money are always {@code equals},
+ * two amounts that represent the same sum of money are {@code equals}
  * regardless of the scale of the {@link BigDecimal} they were built from.
  * {@code BigDecimal} equality is scale-sensitive — {@code 500} and
  * {@code 500.00} are not equal — which makes an un-normalised money type
  * surprising to compare.
+ *
+ * <p>The exception is a currency that declares no minor units at all
+ * ({@code getDefaultFractionDigits()} returns {@code -1}, as pseudo-currencies
+ * such as {@code XXX} do). There is no scale to normalise to, so those amounts
+ * are stored as supplied and comparing them stays scale-sensitive.
  */
 public record MonetaryAmount(Currency currency, BigDecimal amount) {
     /**

--- a/src/main/java/accounting/patterns/MonetaryAmount.java
+++ b/src/main/java/accounting/patterns/MonetaryAmount.java
@@ -1,22 +1,50 @@
 package accounting.patterns;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.util.Currency;
 import java.util.Objects;
 
 /**
  * Represents an immutable monetary amount with a specific currency.
- * This class is thread-safe and can be used as a value type.
+ * This record is thread-safe and can be used as a value type.
+ *
+ * <p>The amount is normalised on construction to the number of decimal places
+ * the currency actually uses ({@link Currency#getDefaultFractionDigits()}), so
+ * two amounts that represent the same sum of money are always {@code equals},
+ * regardless of the scale of the {@link BigDecimal} they were built from.
+ * {@code BigDecimal} equality is scale-sensitive — {@code 500} and
+ * {@code 500.00} are not equal — which makes an un-normalised money type
+ * surprising to compare.
  */
-public final record MonetaryAmount(Currency currency, BigDecimal amount) {
+public record MonetaryAmount(Currency currency, BigDecimal amount) {
+    /**
+     * The rounding applied when an amount carries more precision than its
+     * currency can represent.
+     */
+    private static final RoundingMode ROUNDING = RoundingMode.HALF_UP;
+
+    /**
+     * Zero US dollars, the identity for {@link #add(MonetaryAmount)} in USD.
+     */
     public static final MonetaryAmount ZERO = of("USD", 0);
 
     /**
-     * Creates a new MonetaryAmount with validation.
+     * Creates a new MonetaryAmount, validating its parts and normalising the
+     * amount to the currency's scale.
+     *
+     * @throws NullPointerException if currency or amount is null
      */
     public MonetaryAmount {
         Objects.requireNonNull(currency, "Currency must not be null");
         Objects.requireNonNull(amount, "Amount must not be null");
+        amount = normalise(currency, amount);
+    }
+
+    private static BigDecimal normalise(Currency currency, BigDecimal amount) {
+        int fractionDigits = currency.getDefaultFractionDigits();
+        // Pseudo-currencies such as XXX report -1; leave those amounts untouched.
+        return fractionDigits < 0 ? amount : amount.setScale(fractionDigits, ROUNDING);
     }
 
     /**
@@ -35,12 +63,15 @@ public final record MonetaryAmount(Currency currency, BigDecimal amount) {
 
     /**
      * Adds another MonetaryAmount to this one, ensuring currencies match.
+     *
      * @throws IllegalArgumentException if currencies don't match
      */
     public MonetaryAmount add(MonetaryAmount other) {
+        Objects.requireNonNull(other, "Amount to add must not be null");
         if (!currency.equals(other.currency)) {
-            throw new IllegalArgumentException("Cannot add amounts with different currencies: " + 
-                currency.getCurrencyCode() + " != " + other.currency.getCurrencyCode());
+            throw new IllegalArgumentException(
+                    "Cannot add amounts with different currencies: %s != %s"
+                            .formatted(currency.getCurrencyCode(), other.currency.getCurrencyCode()));
         }
         return new MonetaryAmount(currency, amount.add(other.amount));
     }

--- a/src/main/java/accounting/patterns/MultiplyByRatePostingRule.java
+++ b/src/main/java/accounting/patterns/MultiplyByRatePostingRule.java
@@ -1,46 +1,34 @@
 package accounting.patterns;
 
 import java.math.BigDecimal;
-import java.math.RoundingMode;
 import java.util.Currency;
 import java.util.Objects;
 
 /**
  * A posting rule that calculates the monetary amount by multiplying a quantity by a rate.
- * This implementation uses high-precision decimal arithmetic suitable for financial calculations.
+ *
+ * <p>The product is handed to {@link MonetaryAmount}, which rounds it to the
+ * currency's scale.
+ *
+ * @param entryType the type of entries this rule creates
  */
-final class MultiplyByRatePostingRule extends PostingRule {
+public record MultiplyByRatePostingRule(EntryType entryType) implements PostingRule {
     private static final Currency DEFAULT_CURRENCY = Currency.getInstance("USD");
-    private static final int DECIMAL_SCALE = 2;
 
     /**
      * Creates a new MultiplyByRatePostingRule for the specified entry type.
      *
-     * @param type the type of entries this rule will create
-     * @throws NullPointerException if type is null
+     * @throws NullPointerException if entryType is null
      */
-    public MultiplyByRatePostingRule(EntryType type) {
-        super(type);
+    public MultiplyByRatePostingRule {
+        Objects.requireNonNull(entryType, "Entry type must not be null");
     }
 
-    /**
-     * Calculates the monetary amount by multiplying the quantity by the rate.
-     * The result is rounded to 2 decimal places using {@link RoundingMode#HALF_UP}.
-     *
-     * @param quantity the quantity to multiply
-     * @param rate the rate to multiply by
-     * @return the calculated monetary amount in USD
-     * @throws NullPointerException if quantity or rate is null
-     */
     @Override
-    protected MonetaryAmount calculateAmount(Quantity quantity, BigDecimal rate) {
+    public MonetaryAmount calculateAmount(Quantity quantity, BigDecimal rate) {
         Objects.requireNonNull(quantity, "Quantity must not be null");
         Objects.requireNonNull(rate, "Rate must not be null");
 
-        BigDecimal result = BigDecimal.valueOf(quantity.value())
-                .multiply(rate)
-                .setScale(DECIMAL_SCALE, RoundingMode.HALF_UP);
-
-        return MonetaryAmount.of(DEFAULT_CURRENCY, result);
+        return MonetaryAmount.of(DEFAULT_CURRENCY, BigDecimal.valueOf(quantity.value()).multiply(rate));
     }
 }

--- a/src/main/java/accounting/patterns/PostingRule.java
+++ b/src/main/java/accounting/patterns/PostingRule.java
@@ -5,21 +5,19 @@ import java.time.LocalDate;
 import java.util.Objects;
 
 /**
- * Represents a rule for posting accounting entries.
- * This abstract class defines the base functionality for creating entries based on events.
+ * A rule for turning an event into an accounting entry.
+ *
+ * <p>Implementations supply the entry type they produce and the arithmetic that
+ * turns a quantity and a rate into an amount; assembling the {@link Entry} is
+ * common to all of them and lives here.
  */
-abstract class PostingRule  {
-    protected final EntryType eventType;
-
+public interface PostingRule {
     /**
-     * Creates a new PostingRule for the specified entry type.
+     * The type of the entries this rule creates.
      *
-     * @param type the type of entries this rule will create
-     * @throws NullPointerException if type is null
+     * @return the entry type
      */
-    protected PostingRule(EntryType type) {
-        this.eventType = Objects.requireNonNull(type, "Entry type must not be null");
-    }
+    EntryType entryType();
 
     /**
      * Calculates the monetary amount for an entry based on quantity and rate.
@@ -29,7 +27,7 @@ abstract class PostingRule  {
      * @return the calculated monetary amount
      * @throws NullPointerException if quantity or rate is null
      */
-     abstract MonetaryAmount calculateAmount(Quantity quantity, BigDecimal rate);
+    MonetaryAmount calculateAmount(Quantity quantity, BigDecimal rate);
 
     /**
      * Processes an event and creates a corresponding entry.
@@ -40,11 +38,11 @@ abstract class PostingRule  {
      * @return the created entry
      * @throws NullPointerException if any parameter is null
      */
-    public Entry processEvent(LocalDate eventDate, Quantity quantity, BigDecimal rate) {
+    default Entry processEvent(LocalDate eventDate, Quantity quantity, BigDecimal rate) {
         Objects.requireNonNull(eventDate, "Event date must not be null");
         Objects.requireNonNull(quantity, "Quantity must not be null");
         Objects.requireNonNull(rate, "Rate must not be null");
 
-        return Entry.of(eventDate, eventType, calculateAmount(quantity, rate));
+        return Entry.of(eventDate, entryType(), calculateAmount(quantity, rate));
     }
 }

--- a/src/main/java/accounting/patterns/TemporalCollection.java
+++ b/src/main/java/accounting/patterns/TemporalCollection.java
@@ -48,21 +48,7 @@ public final class TemporalCollection<T> {
      */
     public Optional<T> get(LocalDate date) {
         Objects.requireNonNull(date, "Date must not be null");
-        Map.Entry<LocalDate, T> entry = entries.floorEntry(date);
-        return Optional.ofNullable(entry != null ? entry.getValue() : null);
-    }
-
-    /**
-     * Gets the raw value effective on the specified date.
-     * This method is provided for backward compatibility and internal use.
-     * New code should prefer the Optional-returning {@link #get(LocalDate)} method.
-     *
-     * @param date the date to look up
-     * @return the effective value, or null if no value is effective
-     * @throws NullPointerException if date is null
-     */
-    T getRaw(LocalDate date) {
-        return get(date).orElse(null);
+        return Optional.ofNullable(entries.floorEntry(date)).map(Map.Entry::getValue);
     }
 
     /**
@@ -89,7 +75,7 @@ public final class TemporalCollection<T> {
      * @return an Optional containing the earliest date, or empty if the collection is empty
      */
     public Optional<LocalDate> getEarliestDate() {
-        return Optional.ofNullable(entries.firstKey());
+        return Optional.ofNullable(entries.firstEntry()).map(Map.Entry::getKey);
     }
 
     /**
@@ -98,6 +84,6 @@ public final class TemporalCollection<T> {
      * @return an Optional containing the latest date, or empty if the collection is empty
      */
     public Optional<LocalDate> getLatestDate() {
-        return Optional.ofNullable(entries.lastKey());
+        return Optional.ofNullable(entries.lastEntry()).map(Map.Entry::getKey);
     }
 }

--- a/src/test/java/accounting/patterns/AcceptanceTest.java
+++ b/src/test/java/accounting/patterns/AcceptanceTest.java
@@ -1,6 +1,5 @@
 package accounting.patterns;
 
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.math.BigDecimal;
@@ -8,10 +7,11 @@ import java.time.LocalDate;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-public class AcceptanceTest {
+class AcceptanceTest {
     @Test
-    public void test() {
+    void balanceAccumulatesEveryPostedEvent() {
         LocalDate effectiveDate = LocalDate.of(1999, 10, 1);
+        LocalDate balanceDate = LocalDate.of(2020, 10, 1);
         var customer = new Customer("Acme Coffee Makers",
                 new ServiceAgreement(new BigDecimal(10))
                         .addPostingRule(EventType.USAGE, new MultiplyByRatePostingRule(EntryType.BASE_USAGE), effectiveDate)
@@ -22,13 +22,15 @@ public class AcceptanceTest {
         customer.post(EventType.USAGE, effectiveDate.plusMonths(2), new Quantity(50));
         customer.post(EventType.SERVICE, effectiveDate.plusMonths(12), new Quantity(1));
 
-        Assertions.assertEquals(new BigDecimal(600), customer.balance(LocalDate.of(2020, 10, 1)).amount());
+        assertEquals(MonetaryAmount.of("USD", 600), customer.balance(balanceDate));
 
         customer.post(EventType.USAGE, effectiveDate.plusMonths(2), new Quantity(50));
 
-        Assertions.assertEquals(new BigDecimal(1100), customer.balance(LocalDate.of(2020, 10, 1)).amount());
+        assertEquals(MonetaryAmount.of("USD", 1100), customer.balance(balanceDate));
 
+        // Past the second effective date, the later service fee rule applies.
         customer.post(EventType.SERVICE, effectiveDate.plusMonths(25), new Quantity(1));
-        Assertions.assertEquals(new BigDecimal(2100), customer.balance(LocalDate.of(2020, 10, 1)).amount());
+
+        assertEquals(MonetaryAmount.of("USD", 2100), customer.balance(balanceDate));
     }
 }

--- a/src/test/java/accounting/patterns/AnnualServiceFeeRule.java
+++ b/src/test/java/accounting/patterns/AnnualServiceFeeRule.java
@@ -12,6 +12,7 @@ record AnnualServiceFeeRule(EntryType entryType, long amount) implements Posting
 
     @Override
     public MonetaryAmount calculateAmount(Quantity quantity, BigDecimal rate) {
-        return MonetaryAmount.of(USD, BigDecimal.valueOf(quantity.value() * this.amount));
+        return MonetaryAmount.of(USD,
+                BigDecimal.valueOf(quantity.value()).multiply(BigDecimal.valueOf(this.amount)));
     }
 }

--- a/src/test/java/accounting/patterns/AnnualServiceFeeRule.java
+++ b/src/test/java/accounting/patterns/AnnualServiceFeeRule.java
@@ -3,16 +3,15 @@ package accounting.patterns;
 import java.math.BigDecimal;
 import java.util.Currency;
 
-public class AnnualServiceFeeRule extends PostingRule {
-    private final long amount;
-
-    public AnnualServiceFeeRule(EntryType service, long amount) {
-        super(service);
-        this.amount = amount;
-    }
+/**
+ * A flat annual fee, charged per unit of quantity and independent of the
+ * service agreement's rate.
+ */
+record AnnualServiceFeeRule(EntryType entryType, long amount) implements PostingRule {
+    private static final Currency USD = Currency.getInstance("USD");
 
     @Override
-    protected MonetaryAmount calculateAmount(Quantity quantity, BigDecimal rate) {
-        return new MonetaryAmount(Currency.getInstance("USD"), new BigDecimal(quantity.value() * this.amount));
+    public MonetaryAmount calculateAmount(Quantity quantity, BigDecimal rate) {
+        return MonetaryAmount.of(USD, BigDecimal.valueOf(quantity.value() * this.amount));
     }
 }

--- a/src/test/java/accounting/patterns/MonetaryAmountTest.java
+++ b/src/test/java/accounting/patterns/MonetaryAmountTest.java
@@ -12,14 +12,14 @@ class MonetaryAmountTest {
 
     @Test
     void testZeroConstant() {
-        assertEquals(BigDecimal.ZERO, MonetaryAmount.ZERO.amount());
+        assertEquals(new BigDecimal("0.00"), MonetaryAmount.ZERO.amount());
         assertEquals("USD", MonetaryAmount.ZERO.currency().getCurrencyCode());
     }
 
     @Test
     void testFactoryMethodWithLong() {
         MonetaryAmount amount = MonetaryAmount.of("USD", 100);
-        assertEquals(new BigDecimal(100), amount.amount());
+        assertEquals(new BigDecimal("100.00"), amount.amount());
         assertEquals(USD, amount.currency());
     }
 
@@ -71,5 +71,34 @@ class MonetaryAmountTest {
             () -> assertNotEquals(amount1.hashCode(), amount3.hashCode()),
             () -> assertNotEquals(amount1.hashCode(), amount4.hashCode())
         );
+    }
+
+    @Test
+    void amountsAreNormalisedToTheCurrencyScale() {
+        // BigDecimal equality is scale-sensitive, so 500 and 500.00 are not equal
+        // as raw BigDecimals. MonetaryAmount normalises both to the currency's
+        // scale, which makes equal sums of money compare equal.
+        assertNotEquals(new BigDecimal("500"), new BigDecimal("500.00"));
+
+        assertAll(
+            () -> assertEquals(MonetaryAmount.of(USD, new BigDecimal("500")),
+                               MonetaryAmount.of(USD, new BigDecimal("500.00"))),
+            () -> assertEquals(MonetaryAmount.of(USD, new BigDecimal("500")).hashCode(),
+                               MonetaryAmount.of(USD, new BigDecimal("500.00")).hashCode()),
+            () -> assertEquals(new BigDecimal("500.00"),
+                               MonetaryAmount.of(USD, new BigDecimal("500")).amount())
+        );
+    }
+
+    @Test
+    void excessPrecisionIsRoundedToTheCurrencyScale() {
+        assertEquals(new BigDecimal("10.13"), MonetaryAmount.of(USD, new BigDecimal("10.125")).amount());
+    }
+
+    @Test
+    void currenciesWithoutMinorUnitsAreNotGivenAny() {
+        Currency jpy = Currency.getInstance("JPY");
+
+        assertEquals(new BigDecimal("500"), MonetaryAmount.of(jpy, new BigDecimal("500")).amount());
     }
 }

--- a/src/test/java/accounting/patterns/TemporalCollectionTest.java
+++ b/src/test/java/accounting/patterns/TemporalCollectionTest.java
@@ -1,26 +1,25 @@
 package accounting.patterns;
 
-
 import org.junit.jupiter.api.Test;
 
 import java.time.LocalDate;
+import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
 
 
 class TemporalCollectionTest {
     @Test
-    void getReturnsNullWhenEmpty() {
-        assertNull(new TemporalCollection<String>().get(LocalDate.now()));
+    void getReturnsEmptyWhenEmpty() {
+        assertEquals(Optional.empty(), new TemporalCollection<String>().get(LocalDate.now()));
     }
 
     @Test
-    void returnsNullIfNoneValid() {
+    void returnsEmptyIfNoneValid() {
         final TemporalCollection<String> collection = new TemporalCollection<>();
         collection.put(LocalDate.now().plusDays(1), "foo");
 
-        assertNull(collection.get(LocalDate.now()));
+        assertEquals(Optional.empty(), collection.get(LocalDate.now()));
     }
 
     @Test
@@ -28,7 +27,7 @@ class TemporalCollectionTest {
         final TemporalCollection<String> collection = new TemporalCollection<>();
         collection.put(LocalDate.now().minusDays(1), "foo");
 
-        assertEquals("foo", collection.get(LocalDate.now()));
+        assertEquals(Optional.of("foo"), collection.get(LocalDate.now()));
     }
 
     @Test
@@ -37,7 +36,7 @@ class TemporalCollectionTest {
         collection.put(LocalDate.now().minusDays(2), "Day before Yesterday");
         collection.put(LocalDate.now().minusDays(1), "Yesterday");
 
-        assertEquals("Yesterday", collection.get(LocalDate.now()));
+        assertEquals(Optional.of("Yesterday"), collection.get(LocalDate.now()));
     }
 
     @Test
@@ -46,6 +45,26 @@ class TemporalCollectionTest {
         final LocalDate yesterday = LocalDate.now().minusDays(1);
         collection.put(yesterday, "Yesterday");
 
-        assertEquals("Yesterday", collection.get(yesterday));
+        assertEquals(Optional.of("Yesterday"), collection.get(yesterday));
+    }
+
+    @Test
+    void reportsTheDateRangeItCovers() {
+        final TemporalCollection<String> collection = new TemporalCollection<>();
+        final LocalDate earliest = LocalDate.of(1999, 10, 1);
+        final LocalDate latest = earliest.plusYears(2);
+        collection.put(latest, "later");
+        collection.put(earliest, "earlier");
+
+        assertEquals(Optional.of(earliest), collection.getEarliestDate());
+        assertEquals(Optional.of(latest), collection.getLatestDate());
+    }
+
+    @Test
+    void hasNoDateRangeWhenEmpty() {
+        final TemporalCollection<String> collection = new TemporalCollection<>();
+
+        assertEquals(Optional.empty(), collection.getEarliestDate());
+        assertEquals(Optional.empty(), collection.getLatestDate());
     }
 }


### PR DESCRIPTION
Closes #7. Closes #8.

`master` is currently red — `mvn verify` fails with 7 test failures — so no PR here can pass a merge gate until this lands. This fixes that and does the Java upgrade #7 asks for.

## Java 26

`maven.compiler.release` replaces the split `source`/`target` properties and the duplicate `<source>`/`<target>` block on the compiler plugin.

## The 7 failures

**`TemporalCollection` (5).** `get()` returns `Optional`, but its tests still asserted raw values and `null`. Tests now assert `Optional` semantics. `getRaw()` — a backward-compatibility shim with no remaining callers — is removed.

While in there: `getEarliestDate()`/`getLatestDate()` wrapped `firstKey()`/`lastKey()` in `Optional.ofNullable`, which cannot ever produce an empty `Optional` because those methods throw `NoSuchElementException` on an empty map. They use `firstEntry()`/`lastEntry()` now, with tests covering the empty case.

**`BigDecimal` scale (2).** `600` does not equal `600.00` — `BigDecimal.equals` is scale-sensitive. This is #8, and it is the same defect the failing assertions were tripping over.

`MonetaryAmount` now normalises its amount to the currency’s own scale (`Currency.getDefaultFractionDigits()`) in its compact constructor, so equal sums of money compare equal whatever scale they were built from. Rounding lives there instead of being repeated in each posting rule, and currencies with no minor units (JPY) or none declared (XXX) are handled.

## Idiom pass

- `PostingRule` is an interface with a `default processEvent`, so `MultiplyByRatePostingRule` and `AnnualServiceFeeRule` are records.
- `EntryType.fromName`/`EventType.fromName` are streams rather than hand-rolled loops.
- Redundant `final` dropped from record declarations.

## Verification

`mvn verify` on JDK 26: **22 tests, 0 failures**. Also verified green against JUnit 6.1.3 (#14), which can merge straight after this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013cM2ZkKHDjcn4vjdKLT58z